### PR TITLE
Adding access to the operation count

### DIFF
--- a/JXHTTP.podspec
+++ b/JXHTTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'JXHTTP'
-  s.version       = '2.0.2'
+  s.version       = '2.0.3'
   s.source_files  = 'JXHTTP/*.{h,m}'
   s.homepage      = 'https://github.com/tumblr/JXHTTP'
   s.summary       = 'Networking for iOS and OS X.'

--- a/JXHTTP/JXHTTPOperation.h
+++ b/JXHTTP/JXHTTPOperation.h
@@ -303,4 +303,10 @@ typedef NSURLRequest * (^JXHTTPRedirectBlock)(JXHTTPOperation *operation, NSURLR
  */
 + (void)setNetworkActivityIndicatorManager:(id <JXNetworkActivityIndicatorManager>)networkActivityIndicatorManager;
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+
++ (NSUInteger)JXHTTPOperationCount;
+
+#endif
+
 @end

--- a/JXHTTP/JXHTTPOperation.h
+++ b/JXHTTP/JXHTTPOperation.h
@@ -306,12 +306,11 @@ typedef NSURLRequest * (^JXHTTPRedirectBlock)(JXHTTPOperation *operation, NSURLR
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
 
 /**
- *  The number of active operations.
- *  This is used to determine whether or not the activity indicator of the device is shown.
+ *  Whether or not there are active operations that are updating the device's network activity indicator.
  *
- *  @return The number of active operations.
+ *  @return Whether or not there are active operations that are updating the device's network activity indicator.
  */
-+ (NSUInteger)JXHTTPOperationCount;
+@property (readonly) BOOL hasActiveOperationsThatUpdateNetworkActivityIndicator;
 
 #endif
 

--- a/JXHTTP/JXHTTPOperation.h
+++ b/JXHTTP/JXHTTPOperation.h
@@ -305,6 +305,12 @@ typedef NSURLRequest * (^JXHTTPRedirectBlock)(JXHTTPOperation *operation, NSURLR
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
 
+/**
+ *  The number of active operations.
+ *  This is used to determine whether or not the activity indicator of the device is shown.
+ *
+ *  @return The number of active operations.
+ */
 + (NSUInteger)JXHTTPOperationCount;
 
 #endif

--- a/JXHTTP/JXHTTPOperation.m
+++ b/JXHTTP/JXHTTPOperation.m
@@ -33,8 +33,8 @@ static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorMana
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
 
-+ (NSUInteger)JXHTTPOperationCount {
-    return JXHTTPOperationCount;
++ (BOOL)hasActiveOperationsThatUpdateNetworkActivityIndicator {
+    return JXHTTPOperationCount > 0;
 }
 
 #endif

--- a/JXHTTP/JXHTTPOperation.m
+++ b/JXHTTP/JXHTTPOperation.m
@@ -31,6 +31,14 @@ static id <JXNetworkActivityIndicatorManager> JXHTTPNetworkActivityIndicatorMana
 
 @implementation JXHTTPOperation
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_2_0
+
++ (NSUInteger)JXHTTPOperationCount {
+    return JXHTTPOperationCount;
+}
+
+#endif
+
 #pragma mark - Initialization
 
 - (void)dealloc


### PR DESCRIPTION
Adds access to the internal operation count used for determining when determining the network activity indicator visibility.
