### PR TITLE
`hasActiveOperationsThatUpdateNetworkActivityIndicator` shouldn’t be a property

### DIFF
--- a/JXHTTP.podspec
+++ b/JXHTTP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'JXHTTP'
-  s.version       = '3.0.1'
+  s.version       = '3.0.2'
   s.source_files  = 'JXHTTP/*.{h,m}'
   s.homepage      = 'https://github.com/tumblr/JXHTTP'
   s.summary       = 'Networking for iOS and OS X.'

--- a/JXHTTP/JXHTTPOperation.h
+++ b/JXHTTP/JXHTTPOperation.h
@@ -310,7 +310,7 @@ typedef NSURLRequest * (^JXHTTPRedirectBlock)(JXHTTPOperation *operation, NSURLR
  *
  *  @return Whether or not there are active operations that are updating the device's network activity indicator.
  */
-@property (readonly) BOOL hasActiveOperationsThatUpdateNetworkActivityIndicator;
++ (BOOL)hasActiveOperationsThatUpdateNetworkActivityIndicator;
 
 #endif
 


### PR DESCRIPTION
I changed this to a property but it’s actually a method on the class not on instance of classes.

Also bumps version to 3.0.2
