### PR TITLE
Fix logical error in KVO Code

### DIFF
--- a/JXHTTP/JXHTTPOperationQueue.m
+++ b/JXHTTP/JXHTTPOperationQueue.m
@@ -154,7 +154,7 @@ static NSInteger JXHTTPOperationQueueDefaultMaxOps = 4;
     }
 
     if (object == self && [keyPath isEqualToString:@"operations"]) {
-        if (![[change objectForKey:NSKeyValueChangeKindKey] intValue] == NSKeyValueChangeSetting)
+        if ([[change objectForKey:NSKeyValueChangeKindKey] intValue] != NSKeyValueChangeSetting)
             return;
         
         NSDate *now = [[NSDate alloc] init];


### PR DESCRIPTION
As a warning rightly indicated, the `!` operator was only being applied to the lefthand side of this comparison, meaning that this early return would only be evaluated if the value in the change dictionary was `nil` (which, according to the docs, should be never).

The intention was that we would return early if this is not a KeyValueChange event, which would make NSKeyValueChangeOldKey `nil`. This fixes the logic and removes the warning.
